### PR TITLE
Feature/2021.3.1 support

### DIFF
--- a/jbwsl2/center.py
+++ b/jbwsl2/center.py
@@ -84,7 +84,7 @@ class CentralWidget(QWidget):
                     return
 
                 # search for wrongly formatted path
-                result = re.sub(r'(\$)\1+', r'\1', content)
+                result = re.sub(r'wsl(\$)\1+', r'wsl\1', content)
                 result = re.sub(
                     r'(\"\/\/wsl[\$]*\/[a-zA-Z\- 0-9\.\:\/]*\")',
                     lambda match: './{}'.format(match.group().replace('"', '').replace(invalid_path_component, '').lstrip('/')),

--- a/jbwsl2/center.py
+++ b/jbwsl2/center.py
@@ -69,6 +69,8 @@ class CentralWidget(QWidget):
         if latest_file in self.files:
             return
 
+        self.files.append(latest_file)
+
         self.overview.set_input("{}New file: {}...\n".format(self.overview.input.toPlainText(), latest_file))
         invalid_path_component = self.project_path.replace('\\', '/')
 
@@ -77,15 +79,16 @@ class CentralWidget(QWidget):
                 f = open(latest_file, 'r+')
                 content = f.read()
 
-                match = re.search(r'(\"\/\/wsl\$\/[a-zA-Z\- 0-9\.\:\/]*\")', content)
+                match = re.search(r'(\"\/\/wsl[\$]*\/[a-zA-Z\- 0-9\.\:\/]*\")', content)
                 if not match:
                     return
 
                 # search for wrongly formatted path
+                result = re.sub(r'(\$)\1+', r'\1', content)
                 result = re.sub(
-                    r'(\"\/\/wsl\$\/[a-zA-Z\- 0-9\.\:\/]*\")',
+                    r'(\"\/\/wsl[\$]*\/[a-zA-Z\- 0-9\.\:\/]*\")',
                     lambda match: './{}'.format(match.group().replace('"', '').replace(invalid_path_component, '').lstrip('/')),
-                    content
+                    result
                 )
 
                 f.seek(0)
@@ -98,8 +101,6 @@ class CentralWidget(QWidget):
                 ))
 
                 self.overview.set_output(result)
-
-                self.files.append(latest_file)
                 break
             except Exception as e:
                 print(str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyQt6 = "~=6.1.0"
-pyinstaller = "~=4.4"
+PyQt6~=6.1.0
+pyinstaller~=4.4

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='jbwsl2',
-    version='1.0.0',
+    version='1.0.1',
     license='GNU GPLv3',
     packages=find_packages(exclude=['docs']),
     include_package_data=True,
     package_data={'': ['*.png']},
-    url='https://github.com/cedriclevarlet/jetbrains.invalid-interpolation',
+    url='https://github.com/cedriclevarlet/jbwsl2',
     author='Cédric Le Varlet',
     author_email='cedric@levarlet.fr',
     description='A curious way to resolve the invalid-interpolation errors which occurs on JetBrain\'s IDEs when attempting to run a docker-compose application in WSL2.',


### PR DESCRIPTION
After testing jetbrain's intellij 2021.3.2 it was found that they now add a second dollar sign in their mapping's paths. Whilst this now allows the generated file to be parsed, the mappings did not result in a functional environment. 

This PR aims to replace the duplicated dollar sign and allows the conversion to a relative path.

Although this was not validated, it could be that this PR is only necessary should the user defined docker-compose.yml also use relative paths instead of absolute paths.
